### PR TITLE
Add image restoration example

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -14,6 +14,10 @@ const starterImages = [
   {
     imageUrl: 'https://replicate.delivery/pbxt/N5trWTJCJQbJVWz5nhLEscS1w16r1hGl5zuWceJhVSnWZfGu/mona-lisa-1024.jpg',
     suggestedPrompt: 'close her eyes',
+  },
+	{
+    imageUrl: 'https://replicate.delivery/mgxm/b033ff07-1d2e-4768-a137-6c16b5ed4bed/d_1.png',
+    suggestedPrompt: 'Convert to a high-quality restoration, enhancing details and removing any damage or degradation',
   }
 ]
 
@@ -482,7 +486,7 @@ function App() {
 
               {/* Starter Images Section */}
               <div className="text-center text-gray-600 text-base mb-4 font-medium">Or choose a starting image:</div>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
                 {starterImages.map((starter, idx) => (
                   <button
                     key={idx}


### PR DESCRIPTION
<img width="880" alt="image" src="https://github.com/user-attachments/assets/727e79cf-7e42-473c-9317-8ce7300168a9" />

This pull request adds a new starter image to the `starterImages` array and updates the layout to accommodate the additional image in the grid display.

### Updates to starter images:

* [`public/app.js`](diffhunk://#diff-2e26cfed7509767f2d1cd3952d2fa7931097bf6ff9a0e4a704186edd03c52d45R17-R20): Added a new starter image with the URL `https://replicate.delivery/mgxm/b033ff07-1d2e-4768-a137-6c16b5ed4bed/d_1.png` and the suggested prompt "Convert to a high-quality restoration, enhancing details and removing any damage or degradation."

### Layout adjustments:

* [`public/app.js`](diffhunk://#diff-2e26cfed7509767f2d1cd3952d2fa7931097bf6ff9a0e4a704186edd03c52d45L485-R489): Updated the grid layout to use 5 columns instead of 4 in medium-sized screens (`md:grid-cols-5`) to accommodate the new starter image.