### PR TITLE
feat: add a Deploy to Cloudflare button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kontext Chat
 
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/replicate/kontext-chat)
+
 A chat app that generates images using Replicate and Cloudflare Workers.
 
 Kontext Chat is powered by [FLUX.1 Kontext Pro](https://replicate.com/black-forest-labs/flux-kontext-pro), a new image model from Black Forest Labs, running on [Replicate](https://replicate.com/black-forest-labs/flux-kontext-pro). The app is built with Hono and React and it deployed on [Cloudflare Workers](https://workers.dev/).


### PR DESCRIPTION
The [Deploy to Cloudflare](https://developers.cloudflare.com/workers/platform/deploy-buttons/) button provides a simple way for developers to deploy your repo to their Cloudflare account 